### PR TITLE
CustomDialogPreference: Properly dispatch onClick from OnDismissListener

### DIFF
--- a/src/org/cyanogenmod/cmparts/CustomDialogPreference.java
+++ b/src/org/cyanogenmod/cmparts/CustomDialogPreference.java
@@ -109,6 +109,7 @@ public class CustomDialogPreference<T extends DialogInterface> extends DialogPre
 
             @Override
             public void onClick(View view) {
+                CustomPreferenceDialogFragment.this.onClick(mDialog, mWhich);
                 if (getCustomizablePreference().onDismissDialog(mDialog, mWhich)) {
                     mDialog.dismiss();
                 }


### PR DESCRIPTION
Needed for correct handling of BUTTON_POSITIVE. Children rely on it for
actually saving their values.

Change-Id: I389e8a031b0c6e1b82e8b0db16fd93832f8b1f7d