### PR TITLE
CMParts: weather: Actually mark selected provider as active

### DIFF
--- a/src/org/cyanogenmod/cmparts/weather/WeatherServiceSettings.java
+++ b/src/org/cyanogenmod/cmparts/weather/WeatherServiceSettings.java
@@ -314,7 +314,6 @@ public class WeatherServiceSettings extends SettingsPreferenceFragment
             if (isActiveProvider()) {
                 return;
             }
-            mInfo.isActive = true;
             setActiveWeatherProviderService();
             notifyChanged();
         }
@@ -352,6 +351,7 @@ public class WeatherServiceSettings extends SettingsPreferenceFragment
         private void setActiveWeatherProviderService() {
             if (!mInfo.isActive) {
                 markAsActiveProvider();
+                mInfo.isActive = true;
                 CMSettings.Secure.putString(mContext.getContentResolver(),
                         CMSettings.Secure.WEATHER_PROVIDER_SERVICE,
                         mInfo.componentName.flattenToString());


### PR DESCRIPTION
Currently, when selecting a provider, we're setting isActive
too early, causing the active state of the provider to never
be persisted.

Set isActive in the appropriate order so that the selected
provider stays active and persistent.

Change-Id: I05208c88ac6849c1e448fed966e76e1968cbe0d5