### PR TITLE
Update reboot action name

### DIFF
--- a/res/xml/power_menu_settings.xml
+++ b/res/xml/power_menu_settings.xml
@@ -20,7 +20,7 @@
     android:title="@string/power_menu_title">
 
     <CheckBoxPreference
-        android:key="reboot"
+        android:key="restart"
         android:title="@string/power_menu_reboot_title"
         android:defaultValue="true" />
 


### PR DESCRIPTION
* Google decided to rename it to `restart`.

Change-Id: I934c00b874c7b0fb234fc4bacd6a6486c231f2a4