### PR TITLE
CMParts: Fix expandable desktop

### DIFF
--- a/src/org/cyanogenmod/cmparts/applications/ExpandedDesktopSettings.java
+++ b/src/org/cyanogenmod/cmparts/applications/ExpandedDesktopSettings.java
@@ -174,7 +174,10 @@ public class ExpandedDesktopSettings extends SettingsPreferenceFragment
 
     @Override
     public void onRebuildComplete(ArrayList<ApplicationsState.AppEntry> entries) {
-        rebuild();
+        if (entries != null) {
+            handleAppEntries(entries);
+            mAllPackagesAdapter.notifyDataSetChanged();
+        }
     }
 
     @Override


### PR DESCRIPTION
* Currently it does not show the per-app-setting
* Fix: When the list was rebuilt, actually display it instead of
  retriggering a rebuild...

Change-Id: Ie2db8795d16aff6bf2069016b51be28aae1ac664