### PR TITLE
[1/3] CMParts: Add CM charging sounds settings

### DIFF
--- a/proguard.flags
+++ b/proguard.flags
@@ -12,6 +12,7 @@
 -keep class org.cyanogenmod.cmparts.power.*
 -keep class org.cyanogenmod.cmparts.privacyguard.*
 -keep class org.cyanogenmod.cmparts.profiles.*
+-keep class org.cyanogenmod.cmparts.sounds.*
 
 # Keep click responders
 -keepclassmembers class com.android.settings.inputmethod.UserDictionaryAddWordActivity {

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -563,4 +563,12 @@
     <string name="expanded_desktop_style_hide_navigation">Hide navigation bar</string>
     <string name="expanded_desktop_style_hide_both">Hide both</string>
     <string name="expanded_desktop_nothing_to_show_text">Turn the switch off to customize your expanded desktop on a per-app basis</string>
+
+    <!-- Sounds: Charging sounds -->
+    <string name="charging_sounds_settings_title">Charging sounds</string>
+    <string name="charging_sounds_enabled_title">Enable</string>
+    <string name="charging_sounds_enabled_summary">Play a sound when connecting or disconnecting a power source</string>
+    <string name="power_notifications_vibrate_title">Vibrate</string>
+    <string name="charging_sounds_ringtone_title">Notification sound</string>
+    <string name="charging_sounds_ringtone_silent">Silent</string>
 </resources>

--- a/res/xml/charging_sounds_settings.xml
+++ b/res/xml/charging_sounds_settings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2016 The CyanogenMod Project
+                   2017 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:key="charging_sounds_settings"
+    android:title="@string/charging_sounds_settings_title">
+
+    <cyanogenmod.preference.GlobalSettingSwitchPreference
+        android:key="charging_sounds_enabled"
+        android:title="@string/charging_sounds_enabled_title"
+        android:summary="@string/charging_sounds_enabled_summary" />
+
+    <cyanogenmod.preference.CMGlobalSettingSwitchPreference
+        android:key="power_notifications_vibrate"
+        android:title="@string/power_notifications_vibrate_title"
+        android:dependency="charging_sounds_enabled" />
+
+    <Preference
+        android:key="charging_sounds_ringtone"
+        android:title="@string/charging_sounds_ringtone_title"
+        android:dependency="charging_sounds_enabled"
+        android:persistent="false" />
+
+</PreferenceScreen>

--- a/res/xml/parts_catalog.xml
+++ b/res/xml/parts_catalog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2016 The CyanogenMod Project
+                   2017 The LineageOS Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -104,5 +105,10 @@
           android:summary="@string/expanded_desktop_settings_summary"
           android:fragment="org.cyanogenmod.cmparts.applications.ExpandedDesktopSettings"
           cm:xmlRes="@xml/expanded_desktop_prefs" />
+
+    <part android:key="charging_sounds_settings"
+          android:title="@string/charging_sounds_settings_title"
+          android:fragment="org.cyanogenmod.cmparts.sounds.ChargingSoundsSettings"
+          cm:xmlRes="@xml/charging_sounds_settings" />
 
 </parts-catalog>

--- a/src/org/cyanogenmod/cmparts/sounds/ChargingSoundsSettings.java
+++ b/src/org/cyanogenmod/cmparts/sounds/ChargingSoundsSettings.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *               2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cyanogenmod.cmparts.sounds;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.media.Ringtone;
+import android.media.RingtoneManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Vibrator;
+import android.provider.Settings;
+import android.support.v7.preference.Preference;
+
+import cyanogenmod.providers.CMSettings;
+
+import org.cyanogenmod.cmparts.R;
+import org.cyanogenmod.cmparts.SettingsPreferenceFragment;
+
+public class ChargingSoundsSettings extends SettingsPreferenceFragment {
+
+    private static final String KEY_POWER_NOTIFICATIONS_VIBRATE = "power_notifications_vibrate";
+    private static final String KEY_CHARGING_SOUNDS_RINGTONE = "charging_sounds_ringtone";
+
+    // Used for power notification uri string if set to silent
+    private static final String RINGTONE_SILENT_URI_STRING = "silent";
+
+    // Request code for charging notification ringtone picker
+    private static final int REQUEST_CODE_CHARGING_NOTIFICATIONS_RINGTONE = 1;
+
+    private Preference mChargingSoundsRingtone;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        addPreferencesFromResource(R.xml.charging_sounds_settings);
+
+        Vibrator vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+        if (vibrator == null || !vibrator.hasVibrator()) {
+            removePreference(KEY_POWER_NOTIFICATIONS_VIBRATE);
+        }
+
+        mChargingSoundsRingtone = findPreference(KEY_CHARGING_SOUNDS_RINGTONE);
+        String curTone = CMSettings.Global.getString(getContentResolver(),
+                CMSettings.Global.POWER_NOTIFICATIONS_RINGTONE);
+        if (curTone == null) {
+            updateChargingRingtone(Settings.System.DEFAULT_NOTIFICATION_URI.toString(), true);
+        } else {
+            updateChargingRingtone(curTone, false);
+        }
+    }
+
+    private void updateChargingRingtone(String toneUriString, boolean persist) {
+        final String toneName;
+
+        if (toneUriString != null && !toneUriString.equals(RINGTONE_SILENT_URI_STRING)) {
+            final Ringtone ringtone = RingtoneManager.getRingtone(getActivity(),
+                    Uri.parse(toneUriString));
+            if (ringtone != null) {
+                toneName = ringtone.getTitle(getActivity());
+            } else {
+                // Unlikely to ever happen, but is possible if the ringtone
+                // previously chosen is removed during an upgrade
+                toneName = "";
+                toneUriString = Settings.System.DEFAULT_NOTIFICATION_URI.toString();
+                persist = true;
+            }
+        } else {
+            // Silent
+            toneName = getString(R.string.charging_sounds_ringtone_silent);
+            toneUriString = RINGTONE_SILENT_URI_STRING;
+        }
+
+        mChargingSoundsRingtone.setSummary(toneName);
+        if (persist) {
+            CMSettings.Global.putString(getContentResolver(),
+                    CMSettings.Global.POWER_NOTIFICATIONS_RINGTONE, toneUriString);
+        }
+    }
+
+    @Override
+    public boolean onPreferenceTreeClick(Preference preference) {
+        if (preference == mChargingSoundsRingtone) {
+            launchNotificationSoundPicker(REQUEST_CODE_CHARGING_NOTIFICATIONS_RINGTONE,
+                    CMSettings.Global.getString(getContentResolver(),
+                    CMSettings.Global.POWER_NOTIFICATIONS_RINGTONE));
+        }
+        return super.onPreferenceTreeClick(preference);
+    }
+
+    private void launchNotificationSoundPicker(int requestCode, String toneUriString) {
+        final Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
+
+        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE,
+                getString(R.string.charging_sounds_ringtone_title));
+        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE,
+                RingtoneManager.TYPE_NOTIFICATION);
+        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI,
+                Settings.System.DEFAULT_NOTIFICATION_URI);
+        if (toneUriString != null && !toneUriString.equals(RINGTONE_SILENT_URI_STRING)) {
+            Uri uri = Uri.parse(toneUriString);
+            if (uri != null) {
+                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, uri);
+            }
+        }
+        startActivityForResult(intent, requestCode);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == REQUEST_CODE_CHARGING_NOTIFICATIONS_RINGTONE
+                && resultCode == Activity.RESULT_OK) {
+            Uri uri = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
+            updateChargingRingtone(uri != null ? uri.toString() : null, true);
+        }
+    }
+}


### PR DESCRIPTION
*) Update where needed for copy from Settings to CMParts.

*) Add updateChargingRingtone() helper to shrink code.

[2/2] Forward port power connect/disconnect notification support

Original commit info:

    [2/2] Power connect/disconnect notification support

    part 1/2: frameworks/base PowerUI and Settings
    http://review.cyanogenmod.org/#/c/35241/

    part 2/2: packages/apps/Settings Sound settings
    http://review.cyanogenmod.org/#/c/35242/

    Change-Id: I7ddd8a47ae4f9a62c586023d151ac42bbe8424c7

    Power sound notifications: fix ringtone picker title

    Change-Id: Ied0a08ec1607b778324e69a7b40bac056235bebf

    Settings: Rename 'Power sounds' to 'Charging sounds' and add summary

    VOld_Change-Id: I1cb872917e2d03f0a1c77c25c27f2a0496f9bc05

Old_Change-Id: Ibde52fcd6fd0fabc9eeefc7e6f5a3971527285d7

Change-Id: If247c184c5ea2a1e13dd22ef121cbc9d5d542fd5
Signed-off-by: STELIX <ssspinni@gmail.com>